### PR TITLE
feat: reworked how config and options are handled and added new options

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "clify": "ncpa0cpl/clify.js#0.0.4",
         "commander": "^9.4.1",
         "date-fns": "^2.29.3",
+        "dilswer": "^2.0.2",
         "git-promise": "^1.0.0",
         "git-url-parse": "^13.1.0",
         "parse-github-repo-url": "^1.4.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,70 @@
+import { GetDataType, OptionalField, Type, assertDataType } from 'dilswer';
+
+const StringRegexp = Type.OneOf(
+    Type.String,
+    Type.RecordOf({
+        regexp: Type.String,
+        flags: OptionalField(Type.String)
+    })
+);
+
+export const ConfigSchema = Type.RecordOf({
+    sloppy: OptionalField(Type.Boolean),
+    dateFormat: OptionalField(Type.String),
+    validLabels: OptionalField(Type.ArrayOf(Type.String)),
+    prTitleMatcher: OptionalField(Type.OneOf(StringRegexp, Type.ArrayOf(StringRegexp))),
+    outputFile: OptionalField(Type.String),
+    onlySince: OptionalField(Type.String)
+});
+
+export type Config = GetDataType<typeof ConfigSchema>;
+
+type Defined<T> = Exclude<T, undefined | null>;
+
+export class ConfigFacade {
+    private readonly config: Readonly<Config>;
+
+    constructor(config: any = {}, overrides: Config = {}) {
+        assertDataType(ConfigSchema, config);
+
+        const conf = { ...config };
+
+        for (const key of Object.keys(overrides) as (keyof Config)[]) {
+            const value = overrides[key];
+
+            if (value != null) {
+                Object.assign(conf, { [key]: value });
+            }
+        }
+
+        this.config = Object.freeze(conf);
+
+        this.validateOnlySince();
+    }
+
+    private validateOnlySince() {
+        const onlySince = this.config.onlySince;
+
+        if (onlySince) {
+            try {
+                const date = new Date(onlySince);
+
+                if (date.toString() === 'Invalid Date') {
+                    throw new Error();
+                }
+            } catch (error) {
+                throw new Error(`Invalid date: ${onlySince}`);
+            }
+        }
+    }
+
+    get<K extends keyof Config>(key: K): Config[K];
+    get<K extends keyof Config>(key: K, defaultValue: Defined<Config[K]>): Defined<Config[K]>;
+    get(key: keyof Config, defaultValue?: any): any {
+        return this.config[key] ?? defaultValue;
+    }
+
+    has(key: keyof Config): boolean {
+        return this.config[key] != null;
+    }
+}

--- a/src/createChangelog.ts
+++ b/src/createChangelog.ts
@@ -1,8 +1,9 @@
 import { format as formatDate } from 'date-fns';
 import enLocale from 'date-fns/locale/en-US/index.js';
+import { ConfigFacade } from './config';
 import { padAllLines } from './pad-all-lines';
 import { Repo } from './repo';
-import { PackageJson, PullRequest, SemverNumber } from './shared-types';
+import { PullRequest, SemverNumber } from './shared-types';
 
 function formatLinkToPullRequest(pullRequestId: string | number, repo: Repo) {
     return `[#${pullRequestId}](https://github.com/${repo.path}/pull/${pullRequestId})`;
@@ -14,27 +15,41 @@ function formatPullRequest(pullRequest: PullRequest, repo: Repo, body?: string |
     return `* ${pullRequest.title} (${formatLinkToPullRequest(pullRequest.id, repo)})\n`;
 }
 
-function doesPrContainImportantChanges(pr: PullRequest, validLabels: Map<string, string>) {
-    return /^feat|fix(:\(\/)).+/i.test(pr.title) || (pr.labels && pr.labels?.some((label) => validLabels.has(label)));
+function doesPrContainImportantChanges(pr: PullRequest, config: ConfigFacade): boolean {
+    const validLabels = new Set(config.get('validLabels', []));
+
+    if (pr.labels && pr.labels?.some((label) => validLabels.has(label))) {
+        return true;
+    }
+
+    const regexp = config.get('prTitleMatcher');
+
+    if (regexp) {
+        const allRegexps = (Array.isArray(regexp) ? regexp : [regexp]).map((r) => {
+            if (typeof r === 'string') {
+                return new RegExp(r);
+            }
+
+            return new RegExp(r.regexp, r.flags);
+        });
+
+        return allRegexps.some((r) => r.test(pr.title));
+    }
+
+    return /^feat|fix[:\/\(].+/i.test(pr.title);
 }
 
 type ChangelogGeneratorFactoryParams = {
     getCurrentDate: () => Date;
-    packageInfo: PackageJson;
+    config: ConfigFacade;
     prDescription: boolean;
 };
 
-export function createChangelogFactory({
-    getCurrentDate,
-    packageInfo,
-    prDescription
-}: ChangelogGeneratorFactoryParams) {
-    const defaultDateFormat = 'MMMM d, yyyy';
-    const { dateFormat = defaultDateFormat } = packageInfo['pr-log'] || {};
+export function createChangelogFactory({ getCurrentDate, config, prDescription }: ChangelogGeneratorFactoryParams) {
+    const dateFormat = config.get('dateFormat', 'MMMM d, yyyy');
 
     return async function createChangelog(
         newVersionNumber: SemverNumber,
-        validLabels: Map<string, string>,
         mergedPullRequests: PullRequest[],
         repo: Repo
     ) {
@@ -44,7 +59,7 @@ export function createChangelogFactory({
         let changelog = `${title}\n\n`;
 
         for (const pr of mergedPullRequests) {
-            if (doesPrContainImportantChanges(pr, validLabels)) {
+            if (doesPrContainImportantChanges(pr, config)) {
                 changelog += formatPullRequest(pr, repo, prDescription ? pr.body : null);
             }
         }

--- a/src/main-action.ts
+++ b/src/main-action.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import prepend from 'prepend';
 import { CliAgentParams, createCliAgent } from './cli'; // eslint-disable-line import/no-unresolved
+import { ConfigFacade } from './config';
 import { createChangelogFactory } from './createChangelog'; // eslint-disable-line import/no-unresolved
 import { ensureCleanLocalGitStateFactory } from './ensureCleanLocalGitState'; // eslint-disable-line import/no-unresolved
 import { findRemoteAliasFactory } from './findRemoteAlias'; // eslint-disable-line import/no-unresolved
@@ -15,20 +16,56 @@ import { PackageJson } from './shared-types';
 
 const ArgIncludePrDescription = Argument.define({
     keyword: '--include-pr-description',
-    flagChar: '-ipd',
+    flagChar: '-n',
     dataType: 'boolean',
     description: 'Include the description of each pull request in the changelog. Default: true.',
     default: true,
     require: true
 });
 
+const ArgPrTitleMatcher = Argument.define({
+    keyword: '--pr-title-matcher',
+    flagChar: '-p',
+    dataType: 'string',
+    description:
+        'A regex patter that will be used to determine if a Pull Request should be included in the changelog. Default: /^feat|fix[:\\/\\(].+/i'
+});
+
+const ArgDateFormat = Argument.define({
+    keyword: '--date-format',
+    flagChar: '-d',
+    dataType: 'string',
+    description: 'The date format to use in the changelog. Default: MMMM d, yyyy'
+});
+
+const ArgValidLabels = Argument.define({
+    keyword: '--valid-labels',
+    flagChar: '-l',
+    dataType: 'string',
+    description:
+        'A comma separated list of PR labels. If a PR has a matching label it will be included in the changelog.'
+});
+
+const ArgOutputFile = Argument.define({
+    keyword: '--output-file',
+    flagChar: '-o',
+    dataType: 'string',
+    description: 'The file to write the changelog to. Default: <cwd>/CHANGELOG.md'
+});
+
+const ArgOnlySince = Argument.define({
+    keyword: '--only-since',
+    flagChar: '-c',
+    dataType: 'string',
+    description:
+        'Only include PRs merged since the given date. This option overrides the default behavior of only including PRs merged since the last tag was created.'
+});
+
 const ArgSloppy = Argument.define({
     keyword: '--sloppy',
     flagChar: '-s',
     dataType: 'boolean',
-    description: 'Skip ensuring clean local git state. Default: false.',
-    default: false,
-    require: true
+    description: 'Skip ensuring clean local git state. Default: false.'
 });
 
 const ArgTrace = Argument.define({
@@ -42,9 +79,9 @@ const ArgTrace = Argument.define({
 
 const ArgVersion = Argument.define({
     keyword: '--target-version',
-    flagChar: '-tv',
+    flagChar: '-v',
     dataType: 'string',
-    description: 'The version number of the release the changelog is being created for.',
+    description: '[Required] The version number of the release the changelog is being created for.',
     require: true
 });
 
@@ -53,23 +90,37 @@ export const MainAction: MainCommandInitializeCallback = () => {
     const trace = new ArgTrace();
     const version = new ArgVersion();
     const includePrDescription = new ArgIncludePrDescription();
+    const prTitleMatcher = new ArgPrTitleMatcher();
+    const dateFormat = new ArgDateFormat();
+    const validLabels = new ArgValidLabels();
+    const outputFile = new ArgOutputFile();
+    const onlySince = new ArgOnlySince();
 
     return {
         run() {
             const { GH_TOKEN } = process.env;
 
-            const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
-            const options = { sloppy: sloppy.value, changelogPath };
+            const packageInfo = JSON.parse(
+                fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
+            ) as PackageJson;
+
+            const config = new ConfigFacade(packageInfo['pr-log'], {
+                prTitleMatcher: prTitleMatcher.value,
+                dateFormat: dateFormat.value,
+                validLabels: validLabels.value?.split(','),
+                sloppy: sloppy.value,
+                outputFile: outputFile.value,
+                onlySince: onlySince.value
+            });
+
             const findRemoteAlias = findRemoteAliasFactory({ git });
             const githubClient = new Octokit();
             if (GH_TOKEN) {
                 githubClient.auth({ type: 'token', token: GH_TOKEN });
             }
-            const getMergedPullRequests = getMergedPullRequestsFactory({ githubClient, git });
+            const getMergedPullRequests = getMergedPullRequestsFactory({ githubClient, git, config });
             const getCurrentDate = () => new Date();
-            const packageInfo = JSON.parse(
-                fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
-            ) as PackageJson;
+
             const dependencies: CliAgentParams = {
                 githubClient,
                 prependFile: promisify(prepend),
@@ -78,13 +129,13 @@ export const MainAction: MainCommandInitializeCallback = () => {
                 getMergedPullRequests,
                 createChangelog: createChangelogFactory({
                     getCurrentDate,
-                    packageInfo,
-                    prDescription: includePrDescription.value
+                    prDescription: includePrDescription.value,
+                    config
                 })
             };
             const cliAgent = createCliAgent(dependencies);
 
-            cliAgent.run(version.value, options).catch((error) => {
+            cliAgent.run(version.value, config).catch((error) => {
                 let message = `Error: ${error.message}`;
 
                 if (trace.value) {

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -15,10 +15,7 @@ export type PackageJson = {
         url?: string;
         type?: string;
     };
-    'pr-log'?: {
-        dateFormat?: string;
-        validLabels?: Array<[string, string]>;
-    };
+    'pr-log'?: unknown;
 };
 
 export type GenerateChangelogOptions = {

--- a/src/validLabels.ts
+++ b/src/validLabels.ts
@@ -1,6 +1,1 @@
-export default new Map([
-    ['breaking', 'Breaking Changes'],
-    ['bug', 'Bug Fixes'],
-    ['feature', 'Features'],
-    ['enhancement', 'Enhancements']
-]);
+export const DefaultValidLabels = ['breaking', 'bug', 'feature', 'enhancement'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1801,7 +1801,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dilswer@npm:2.0.2":
+"dilswer@npm:2.0.2, dilswer@npm:^2.0.2":
   version: 2.0.2
   resolution: "dilswer@npm:2.0.2"
   dependencies:
@@ -4653,6 +4653,7 @@ __metadata:
     clify: "ncpa0cpl/clify.js#0.0.4"
     commander: ^9.4.1
     date-fns: ^2.29.3
+    dilswer: ^2.0.2
     esbuild: ^0.17.17
     eslint: ^8.26.0
     eslint-config-joyn: ^0.39.0


### PR DESCRIPTION
Reworked how the CLI arguments and config options are handled. Most of the config options can now be overridden via CLI arguments. New config options has also been added:

- ` --only-since`/`onlySince` - can be used to opt-out of the default method of determining which PRs should be included in the changelog, and instead use a specified date, all merged PRs past that date will be then included, the date value passed can be either a Unix Timestamp or a ISO Date or DateTime
- `--output-file`/`outputFile` - can be used to define a file to which the generated changelog will be saved to
- `--pr-title-matcher`/`prTitleMatcher` - an regular expression or an array of them, if defined will be used to match against the merged PR titles to determine if a given PR should be included in the changelog