### PR TITLE
fix: added an additional endline character in between the PR title and the body

### DIFF
--- a/src/createChangelog.ts
+++ b/src/createChangelog.ts
@@ -11,7 +11,7 @@ function formatLinkToPullRequest(pullRequestId: string | number, repo: Repo) {
 
 function formatPullRequest(pullRequest: PullRequest, repo: Repo, body?: string | null) {
     if (body)
-        return `* ${pullRequest.title} (${formatLinkToPullRequest(pullRequest.id, repo)})\n${padAllLines(body, 2)}\n`;
+        return `* ${pullRequest.title} (${formatLinkToPullRequest(pullRequest.id, repo)})\n\n${padAllLines(body, 2)}\n`;
     return `* ${pullRequest.title} (${formatLinkToPullRequest(pullRequest.id, repo)})\n`;
 }
 


### PR DESCRIPTION
Fixed a bug where markdown was displaying the PR body on the same line as the PR title, because there was only one end-of-line character in between them