### PR TITLE
feat: renamed the property under which the config in package.json file is located

### DIFF
--- a/src/main-action.ts
+++ b/src/main-action.ts
@@ -120,7 +120,7 @@ export const MainAction: MainCommandInitializeCallback = () => {
                 fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')
             ) as PackageJson;
 
-            const config = new ConfigFacade(packageInfo['pr-log'], {
+            const config = new ConfigFacade(packageInfo['pr-changelog-gen'], {
                 prTitleMatcher: prTitleMatcher.value,
                 dateFormat: dateFormat.value,
                 validLabels: validLabels.value?.split(','),

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -16,7 +16,7 @@ export type PackageJson = {
         url?: string;
         type?: string;
     };
-    'pr-log'?: unknown;
+    'pr-changelog-gen'?: unknown;
 };
 
 export type GenerateChangelogOptions = {


### PR DESCRIPTION
In the original fork the config could be specified in the `package.json` file under a `pr-log` property. This has been renamed to `pr-changelog-gen` to match this forked project name.