### PR TITLE
feat: added main export from the package to make running pr-changelog-gen from a node script

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,7 @@
 {
-  "plugins": ["@typescript-eslint"],
+  "plugins": [
+    "@typescript-eslint"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "./tsconfig.json",
@@ -27,7 +29,10 @@
         "ignoreTemplateLiterals": true
       }
     ],
-    "linebreak-style": ["error", "unix"],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
     "quotes": [
       "error",
       "double",
@@ -35,7 +40,10 @@
         "avoidEscape": true
       }
     ],
-    "semi": ["error", "always"],
+    "semi": [
+      "error",
+      "always"
+    ],
     "@typescript-eslint/consistent-type-imports": 2,
     "@typescript-eslint/consistent-type-exports": 2,
     "@typescript-eslint/member-delimiter-style": 2,
@@ -65,7 +73,9 @@
     "no-restricted-imports": [
       "error",
       {
-        "patterns": [".*"]
+        "patterns": [
+          ".*"
+        ]
       }
     ],
     "@typescript-eslint/ban-types": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "4.0.0",
   "description": "Changelog generator based on GitHub Pull Requests",
   "bin": "dist/bin/pr-changelog-gen.js",
+  "exports": {
+    ".": {
+      "default": "./dist/esm/node-binding.mjs",
+      "types": "./dist/types/node-binding.d.ts"
+    }
+  },
   "scripts": {
     "build": "./scripts/build.mjs",
     "prettier": "prettier '**/*.(yml|json|yaml|md)'",
@@ -24,6 +30,7 @@
     "parse-github-repo-url": "^1.4.1",
     "prepend": "^1.0.2",
     "ramda": "^0.28.0",
+    "reflect-metadata": "^0.1.13",
     "semver": "^7.3.8"
   },
   "devDependencies": {
@@ -52,7 +59,6 @@
     "eslint-plugin-unicorn": "^44.0.2",
     "jest": "^29.5.0",
     "prettier": "^2.7.1",
-    "reflect-metadata": "^0.1.13",
     "typescript": "^5.0.4"
   },
   "repository": {

--- a/src/node-binding.ts
+++ b/src/node-binding.ts
@@ -1,0 +1,135 @@
+import type { Argument } from "clify";
+import "reflect-metadata";
+import {
+  ArgDateFormat,
+  ArgGroupByLabels,
+  ArgGroupByMatchers,
+  ArgIncludePrDescription,
+  ArgOnlySince,
+  ArgOutputFile,
+  ArgPrTitleMatcher,
+  ArgSloppy,
+  ArgTrace,
+  ArgValidLabels,
+  ArgVersion,
+} from "./main-action";
+import type { Constructor } from "./utils/dependency-injector/inject";
+import type { DependencyOverride } from "./utils/dependency-injector/service";
+import { Service } from "./utils/dependency-injector/service";
+
+export { MainAction } from "./main-action";
+
+const ARGS = [
+  ["includePrBody", ArgIncludePrDescription],
+  ["--include-pr-description", ArgIncludePrDescription],
+  ["-n", ArgIncludePrDescription],
+  ["prTitleMatcher", ArgPrTitleMatcher],
+  ["--pr-title-matcher", ArgPrTitleMatcher],
+  ["-p", ArgPrTitleMatcher],
+  ["dateFormat", ArgDateFormat],
+  ["--date-format", ArgDateFormat],
+  ["-d", ArgDateFormat],
+  ["validLabels", ArgValidLabels],
+  ["--valid-labels", ArgValidLabels],
+  ["-l", ArgValidLabels],
+  ["outputFile", ArgOutputFile],
+  ["--output-file", ArgOutputFile],
+  ["-o", ArgOutputFile],
+  ["onlySince", ArgOnlySince],
+  ["--only-since", ArgOnlySince],
+  ["-c", ArgOnlySince],
+  ["groupByLabels", ArgGroupByLabels],
+  ["--group-by-labels", ArgGroupByLabels],
+  ["-gl", ArgGroupByLabels],
+  ["groupByMatchers", ArgGroupByMatchers],
+  ["--group-by-matchers", ArgGroupByMatchers],
+  ["-gm", ArgGroupByMatchers],
+  ["sloppy", ArgSloppy],
+  ["--sloppy", ArgSloppy],
+  ["-s", ArgSloppy],
+  ["trace", ArgTrace],
+  ["--trace", ArgTrace],
+  ["-t", ArgTrace],
+  ["targetVersion", ArgVersion],
+  ["--target-version", ArgVersion],
+  ["-v", ArgVersion],
+] as const;
+
+type TypeName = "string" | "boolean" | "number";
+
+type ArgForKey<A extends ArgKey> = {
+  [K in (typeof ARGS)[number] as K[0]]: K;
+}[A][1];
+
+type TypeNameToType<T extends TypeName> = {
+  string: string;
+  boolean: boolean;
+  number: number;
+}[T];
+
+type ArgKey = (typeof ARGS)[number][0];
+type ArgType<A extends ArgKey> = ArgForKey<A> extends new () => Argument<infer U, any>
+  ? U extends TypeName
+    ? TypeNameToType<U>
+    : never
+  : never;
+
+// @ts-expect-error
+const ARG_MAP = new Map(ARGS);
+
+export const argument = <A extends ArgKey>(
+  argName: A,
+  value: ArgType<A>
+): [Constructor, DependencyOverride] => {
+  const ArgConstructor = ARG_MAP.get(argName);
+
+  if (!ArgConstructor) {
+    throw new Error(`Invalid argument: ${argName}`);
+  }
+
+  return [
+    ArgConstructor,
+    {
+      value,
+      isSet: true,
+      setDefault(v: any) {},
+    },
+  ];
+};
+
+export const arg = argument;
+
+const defaultBindArg = <A extends ArgKey>(
+  argName: A
+): [Constructor, DependencyOverride] => {
+  const ArgConstructor = ARG_MAP.get(argName);
+
+  if (!ArgConstructor) {
+    throw new Error(`Invalid argument: ${argName}`);
+  }
+
+  const a = {
+    value: undefined,
+    isSet: false,
+    setDefault(v: any) {
+      if (!this.isSet) {
+        this.value = v;
+        this.isSet = true;
+      }
+    },
+  };
+
+  return [ArgConstructor, a];
+};
+
+Service.setDefaultDependency(...defaultBindArg("--date-format"));
+Service.setDefaultDependency(...defaultBindArg("--group-by-matchers"));
+Service.setDefaultDependency(...defaultBindArg("--group-by-labels"));
+Service.setDefaultDependency(...defaultBindArg("--include-pr-description"));
+Service.setDefaultDependency(...defaultBindArg("--only-since"));
+Service.setDefaultDependency(...defaultBindArg("--output-file"));
+Service.setDefaultDependency(...defaultBindArg("--pr-title-matcher"));
+Service.setDefaultDependency(...defaultBindArg("--sloppy"));
+Service.setDefaultDependency(...defaultBindArg("--target-version"));
+Service.setDefaultDependency(...defaultBindArg("--trace"));
+Service.setDefaultDependency(...defaultBindArg("--valid-labels"));


### PR DESCRIPTION
`pr-changelog-gen` now has a main export that contains everything you need to easily use it from a node script.

**Example**

```ts
import { MainAction, argument } from "pr-changelog-gen";

const action = MainAction.init(
  argument("-v", "1.0.0"),
  argument("-c", "2023-01-01"),
  argument("--sloppy", true)
);

await action.run();

```