### PR TITLE
fix: order of matchers group to be the same as defined in config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,6 +73,13 @@
         },
         "extendDefaults": true
       }
+    ],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "ImportDeclaration[source.value=/.+dist.+/i]",
+        "message": "Imports from the dist folder are not allowed."
+      }
     ]
   }
 }

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -1,14 +1,13 @@
 import type { GetDataType } from "dilswer";
 import { OptionalField, Type, assertDataType } from "dilswer";
 
-const StringRegexp = Type.OneOf(
-  Type.String,
-  Type.RecordOf({
-    regexp: Type.String,
-    flags: OptionalField(Type.String),
-    label: OptionalField(Type.String),
-  })
-);
+const LabeledRegex = Type.RecordOf({
+  regexp: Type.String,
+  flags: OptionalField(Type.String),
+  label: OptionalField(Type.String),
+});
+
+const StringRegexp = Type.OneOf(Type.String, LabeledRegex);
 
 export const ConfigSchema = Type.RecordOf({
   sloppy: OptionalField(Type.Boolean),
@@ -23,6 +22,8 @@ export const ConfigSchema = Type.RecordOf({
 });
 
 export type Config = GetDataType<typeof ConfigSchema>;
+
+export type LabeledRegexp = GetDataType<typeof LabeledRegex>;
 
 type Defined<T> = Exclude<T, undefined | null>;
 


### PR DESCRIPTION
Fixed an error in the ordering of PR groups in changelog. The order of elements should be exactly the same as the order of matchers defined in the `prTitleMatcher` config option, this however was not the case. Has been fixed now.